### PR TITLE
Handle empty extra_package gracefully

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -30,8 +30,10 @@ end
 # naming of these packages is very inconsistent across kernel
 # versions
 extra_package = %x(apt-cache search linux-image-extra-`uname -r | grep --only-matching -e [0-9]\.[0-9]\.[0-9]-[0-9]*` | cut -d " " -f 1).strip
-package extra_package do
-  not_if { node["kernel"]["modules"].has_key?("aufs") }
+unless extra_package.empty?
+  package extra_package do
+    not_if { node["kernel"]["modules"].has_key?("aufs") }
+  end
 end
 
 execute "fetch go" do


### PR DESCRIPTION
On Ubuntu 12.04 LTS it's possible:

```
%x(apt-cache search linux-image-extra-`uname -r | grep --only-matching -e [0-9]\.[0-9]\.[0-9]-[0-9]*` | cut -d " " -f 1).strip
```

..returns an empty string.  This causes a package[] error.  Added a simple empty string check to handle this error condition.
