### PR TITLE
name attribute added

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name             "docker"
 maintainer       "Troy Howard"
 maintainer_email "thoward37@gmail.com"
 license          "Apache 2.0"


### PR DESCRIPTION
Chef 12.3.0 was failing with:

ERROR: Could not read /tmp/kitchen/cookbooks/docker into a Chef object: Cookbook loaded at path(s) [/tmp/kitchen/cookbooks/docker] has invalid metadata: The `name' attribute is required in cookbook metadata
